### PR TITLE
Abstract away ADPCM subformats, add "SB4" codec

### DIFF
--- a/adpcm-lib.c
+++ b/adpcm-lib.c
@@ -47,16 +47,31 @@ static const int index_table[] = {
     -1, -1, -1, -1, 2, 4, 6, 8
 };
 
+static const int sb4_index_table[8] = {-1, 0, 0, 0, 0, 1, 1, 1};
+static const int32_t sb4_step_table[4] = {0x100, 0x200, 0x400, 0x800};
+
 struct adpcm_channel {
     int32_t pcmdata;                        // current PCM value
     int32_t error, weight, history [2];     // for noise shaping
     int8_t index;                           // current index into step size table
+
+    uint8_t (*encode_sample) (struct adpcm_channel *, int32_t);
+    void (*decode_sample) (struct adpcm_channel *, int);
 };
 
 struct adpcm_context {
     struct adpcm_channel channels [2];
     int num_channels, lookahead, noise_shaping;
+    void (*init_block) (struct adpcm_context *, uint8_t *, const int32_t , const int8_t );
 };
+
+static void init_ima_block (struct adpcm_context *pcnxt, uint8_t *outbuf, const int32_t init_pcmdata, const int8_t init_index);
+static void decode_ima_sample (struct adpcm_channel *pchan, int nibble);
+static uint8_t encode_ima_sample (struct adpcm_channel *pchan, int32_t csample);
+
+static void init_sb4_block (struct adpcm_context *pcnxt, uint8_t *outbuf, const int32_t init_pcmdata, const int8_t init_index);
+static void decode_sb4_sample (struct adpcm_channel *pchan, int code);
+static uint8_t encode_sb4_sample (struct adpcm_channel *pchan, int32_t csample);
 
 /* Create ADPCM encoder context with given number of channels.
  * The returned pointer is used for subsequent calls. Note that
@@ -66,7 +81,7 @@ struct adpcm_context {
  * for encoding independent frames).
  */
 
-void *adpcm_create_context (int num_channels, int lookahead, int noise_shaping, int32_t initial_deltas [2])
+void *adpcm_create_ima_context (int num_channels, int lookahead, int noise_shaping, int32_t initial_deltas [2])
 {
     struct adpcm_context *pcnxt = malloc (sizeof (struct adpcm_context));
     int ch, i;
@@ -75,15 +90,49 @@ void *adpcm_create_context (int num_channels, int lookahead, int noise_shaping, 
     pcnxt->noise_shaping = noise_shaping;
     pcnxt->num_channels = num_channels;
     pcnxt->lookahead = lookahead;
+    pcnxt->init_block = init_ima_block;
 
     // given the supplied initial deltas, search for and store the closest index
 
     for (ch = 0; ch < num_channels; ++ch)
+    {
+        pcnxt->channels[ch].encode_sample = encode_ima_sample;
+        pcnxt->channels[ch].decode_sample = decode_ima_sample;
+
         for (i = 0; i <= 88; i++)
             if (i == 88 || initial_deltas [ch] < ((int32_t) step_table [i] + step_table [i+1]) / 2) {
                 pcnxt->channels [ch].index = i;
                 break;
             }
+    }
+
+    return pcnxt;
+}
+
+void *adpcm_create_sb4_context (int num_channels, int lookahead, int noise_shaping, int32_t initial_deltas [2])
+{
+    struct adpcm_context *pcnxt = malloc (sizeof (struct adpcm_context));
+    int ch, i;
+
+    memset (pcnxt, 0, sizeof (struct adpcm_context));
+    pcnxt->noise_shaping = noise_shaping;
+    pcnxt->num_channels = num_channels;
+    pcnxt->lookahead = lookahead;
+    pcnxt->init_block = init_sb4_block;
+
+    // given the supplied initial deltas, search for and store the closest index
+
+    for (ch = 0; ch < num_channels; ++ch)
+    {
+        pcnxt->channels[ch].encode_sample = encode_sb4_sample;
+        pcnxt->channels[ch].decode_sample = decode_sb4_sample;
+
+        for (i = 0; i <= 2; i++)
+            if (i == 2 || initial_deltas [ch] < ((int32_t) sb4_step_table [i] + sb4_step_table [i+1]) / 2) {
+                pcnxt->channels [ch].index = i;
+                break;
+            }
+    }
 
     return pcnxt;
 }
@@ -120,40 +169,17 @@ static void get_decode_parameters (struct adpcm_context *pcnxt, int32_t *init_pc
 
 static double minimum_error (const struct adpcm_channel *pchan, int nch, int32_t csample, const int16_t *sample, int depth, int *best_nibble)
 {
-    int32_t delta = csample - pchan->pcmdata;
     struct adpcm_channel chan = *pchan;
-    uint16_t step = step_table[chan.index];
-    uint16_t trial_delta = (step >> 3);
     int nibble, nibble2;
     double min_error;
 
-    if (delta < 0) {
-        int mag = (-delta << 2) / step;
-        nibble = 0x8 | (mag > 7 ? 7 : mag);
-    }
-    else {
-        int mag = (delta << 2) / step;
-        nibble = mag > 7 ? 7 : mag;
-    }
+    nibble = chan.encode_sample(&chan, csample);
 
-    if (nibble & 1) trial_delta += (step >> 2);
-    if (nibble & 2) trial_delta += (step >> 1);
-    if (nibble & 4) trial_delta += step;
-
-    if (nibble & 8)
-        chan.pcmdata -= trial_delta;
-    else
-        chan.pcmdata += trial_delta;
-
-    CLIP(chan.pcmdata, -32768, 32767);
     if (best_nibble) *best_nibble = nibble;
     min_error = (double) (chan.pcmdata - csample) * (chan.pcmdata - csample);
 
-    if (depth) {
-        chan.index += index_table[nibble & 0x07];
-        CLIP(chan.index, 0, 88);
+    if (depth)
         min_error += minimum_error (&chan, nch, sample [nch], sample + nch, depth - 1, NULL);
-    }
     else
         return min_error;
 
@@ -164,26 +190,12 @@ static double minimum_error (const struct adpcm_channel *pchan, int nch, int32_t
             continue;
 
         chan = *pchan;
-        trial_delta = (step >> 3);
-
-        if (nibble2 & 1) trial_delta += (step >> 2);
-        if (nibble2 & 2) trial_delta += (step >> 1);
-        if (nibble2 & 4) trial_delta += step;
-
-        if (nibble2 & 8)
-            chan.pcmdata -= trial_delta;
-        else
-            chan.pcmdata += trial_delta;
-
-        CLIP(chan.pcmdata, -32768, 32767);
+        chan.decode_sample(&chan, nibble2);
 
         error = (double) (chan.pcmdata - csample) * (chan.pcmdata - csample);
 
         if (error < min_error) {
-            chan.index += index_table[nibble2 & 0x07];
-            CLIP(chan.index, 0, 88);
             error += minimum_error (&chan, nch, sample [nch], sample + nch, depth - 1, NULL);
-
             if (error < min_error) {
                 if (best_nibble) *best_nibble = nibble2;
                 min_error = error;
@@ -194,13 +206,107 @@ static double minimum_error (const struct adpcm_channel *pchan, int nch, int32_t
     return min_error;
 }
 
+static void init_ima_block (struct adpcm_context *pcnxt, uint8_t *outbuf, const int32_t init_pcmdata, const int8_t init_index)
+{
+    outbuf[0] = init_pcmdata;
+    outbuf[1] = init_pcmdata >> 8;
+    outbuf[2] = init_index;
+    outbuf[3] = 0;
+}
+
+static void decode_ima_sample (struct adpcm_channel *pchan, int nibble)
+{
+    uint16_t step = step_table[pchan->index];
+    uint16_t trial_delta = (step >> 3);
+
+    if (nibble & 1) trial_delta += (step >> 2);
+    if (nibble & 2) trial_delta += (step >> 1);
+    if (nibble & 4) trial_delta += step;
+
+    if (nibble & 8)
+        pchan->pcmdata -= trial_delta;
+    else
+        pchan->pcmdata += trial_delta;
+
+    pchan->index += index_table[nibble & 0x07];
+    CLIP(pchan->index, 0, 88);
+    CLIP(pchan->pcmdata, -32768, 32767);
+}
+
+static uint8_t encode_ima_sample (struct adpcm_channel *pchan, int32_t csample)
+{
+    int32_t delta = csample - pchan->pcmdata;
+    uint16_t step = step_table[pchan->index];
+    int nibble;
+
+    if (delta < 0) {
+        int mag = (-delta << 2) / step;
+        nibble = 0x8 | (mag > 7 ? 7 : mag);
+    }
+    else {
+        int mag = (delta << 2) / step;
+        nibble = mag > 7 ? 7 : mag;
+    }
+
+    decode_ima_sample(pchan, nibble);
+
+    return nibble;
+}
+
+static void init_sb4_block (struct adpcm_context *pcnxt, uint8_t *outbuf, const int32_t init_pcmdata, const int8_t init_index)
+{
+    outbuf[0] = (init_pcmdata + 32768)/256; // convert signed 16-bit sample to unsigned 8-bit
+    outbuf[1] = 0;
+    outbuf[2] = init_index;
+    outbuf[3] = 0;
+}
+
+static void decode_sb4_sample (struct adpcm_channel *pchan, int code)
+{
+    int sample;
+    int32_t delta, diff;
+
+    delta = sb4_step_table[pchan->index];
+    diff = (code & 0x07) * delta;
+    if (code & 0x08) {
+        diff = -diff;
+    }
+
+    sample = pchan->pcmdata + diff;
+    CLIP(sample, -32768, 32767);
+
+    pchan->index += sb4_index_table[code & 7];
+    CLIP(pchan->index, 0, 3);
+
+    pchan->pcmdata = sample;
+}
+
+static uint8_t encode_sb4_sample (struct adpcm_channel *pchan, int32_t csample)
+{
+    int32_t delta;
+    int sign, code;
+
+    sign = 0;
+    delta = csample - pchan->pcmdata;
+    if (delta < 0) {
+        sign = 0x8;
+        delta = -delta;
+    }
+    CLIP(delta, 0, 0xffff);
+
+    code = delta / sb4_step_table[pchan->index];
+    code = sign | (code > 0x7 ? 0x7 : code);
+
+    decode_sb4_sample(pchan, code);
+
+    return code;
+}
+
 static uint8_t encode_sample (struct adpcm_context *pcnxt, int ch, const int16_t *sample, int num_samples)
 {
     struct adpcm_channel *pchan = pcnxt->channels + ch;
+    int depth, nibble;
     int32_t csample = *sample;
-    int depth = num_samples - 1, nibble;
-    uint16_t step = step_table[pchan->index];
-    uint16_t trial_delta = (step >> 3);
 
     if (pcnxt->noise_shaping == NOISE_SHAPING_DYNAMIC) {
         int32_t sam = (3 * pchan->history [0] - pchan->history [1]) >> 1;
@@ -227,23 +333,13 @@ static uint8_t encode_sample (struct adpcm_context *pcnxt, int ch, const int16_t
     else if (pcnxt->noise_shaping == NOISE_SHAPING_STATIC)
         pchan->error = -(csample -= pchan->error);
 
+    depth = num_samples - 1;
     if (depth > pcnxt->lookahead)
         depth = pcnxt->lookahead;
 
     minimum_error (pchan, pcnxt->num_channels, csample, sample, depth, &nibble);
 
-    if (nibble & 1) trial_delta += (step >> 2);
-    if (nibble & 2) trial_delta += (step >> 1);
-    if (nibble & 4) trial_delta += step;
-
-    if (nibble & 8)
-        pchan->pcmdata -= trial_delta;
-    else
-        pchan->pcmdata += trial_delta;
-
-    pchan->index += index_table[nibble & 0x07];
-    CLIP(pchan->index, 0, 88);
-    CLIP(pchan->pcmdata, -32768, 32767);
+    pchan->decode_sample (pchan, nibble);
 
     if (pcnxt->noise_shaping)
         pchan->error += pchan->pcmdata;
@@ -309,10 +405,8 @@ int adpcm_encode_block (void *p, uint8_t *outbuf, size_t *outbufsize, const int1
 
     for (ch = 0; ch < pcnxt->num_channels; ch++) {
         init_pcmdata[ch] = *inbuf++;
-        outbuf[0] = init_pcmdata[ch];
-        outbuf[1] = init_pcmdata[ch] >> 8;
-        outbuf[2] = init_index[ch];
-        outbuf[3] = 0;
+
+        pcnxt->init_block(pcnxt, outbuf, init_pcmdata[ch], init_index[ch]);
 
         outbuf += 4;
         *outbufsize += 4;
@@ -340,7 +434,7 @@ int adpcm_encode_block (void *p, uint8_t *outbuf, size_t *outbufsize, const int1
  * Returns number of converted composite samples (total samples divided by number of channels)
  */ 
 
-int adpcm_decode_block (int16_t *outbuf, const uint8_t *inbuf, size_t inbufsize, int channels)
+int adpcm_decode_ima_block (int16_t *outbuf, const uint8_t *inbuf, size_t inbufsize, int channels)
 {
     int ch, samples = 1, chunks;
     int32_t pcmdata[2];
@@ -402,6 +496,72 @@ int adpcm_decode_block (int16_t *outbuf, const uint8_t *inbuf, size_t inbufsize,
                 outbuf [(i * 2 + 1) * channels] = pcmdata[ch];
 
                 inbuf++;
+            }
+
+            outbuf++;
+        }
+
+        outbuf += channels * 7;
+    }
+
+    return samples;
+}
+
+int adpcm_decode_sb4_block (int16_t *outbuf, const uint8_t *inbuf, size_t inbufsize, int channels)
+{
+    int ch, samples = 1, chunks;
+    int32_t pcmdata[2];
+    int8_t index[2];
+
+    if (inbufsize < (uint32_t) channels * 4)
+        return 0;
+
+    for (ch = 0; ch < channels; ch++) {
+        *outbuf++ = pcmdata[ch] = (int16_t)((int)inbuf[0] * 256 - 32768);
+        index[ch] = inbuf [2];
+
+        if (index [ch] < 0 || index [ch] > 3 || inbuf [3])     // sanitize the input a little...
+            return 0;
+
+        inbufsize -= 4;
+        inbuf += 4;
+    }
+
+    chunks = inbufsize / (channels * 4);
+    samples += chunks * 8;
+
+    while (chunks--) {
+        int ch, i;
+
+        for (ch = 0; ch < channels; ++ch) {
+
+            for (i = 0; i < 4; ++i) {
+                int delta;
+                int in = *inbuf++;
+
+                delta = (in & 0x07) * sb4_step_table[index[ch]];
+                if (in & 0x8)
+                    pcmdata[ch] -= delta;
+                else
+                    pcmdata[ch] += delta;
+
+                index[ch] += sb4_index_table[in & 0x7];
+                CLIP(index[ch], 0, 3);
+                CLIP(pcmdata[ch], -32768, 32767);
+                outbuf [i * 2 * channels] = pcmdata[ch];
+
+                in = in >> 4;
+
+                delta = (in & 0x07) * sb4_step_table[index[ch]];
+                if (in & 0x8)
+                    pcmdata[ch] -= delta;
+                else
+                    pcmdata[ch] += delta;
+
+                index[ch] += sb4_index_table[in & 0x7];
+                CLIP(index[ch], 0, 3);
+                CLIP(pcmdata[ch], -32768, 32767);
+                outbuf [(i * 2 + 1) * channels] = pcmdata[ch];
             }
 
             outbuf++;

--- a/adpcm-lib.h
+++ b/adpcm-lib.h
@@ -31,9 +31,11 @@ extern "C" {
 #endif
 
 
-void *adpcm_create_context (int num_channels, int lookahead, int noise_shaping, int32_t initial_deltas [2]);
+void *adpcm_create_ima_context (int num_channels, int lookahead, int noise_shaping, int32_t initial_deltas [2]);
+void *adpcm_create_sb4_context (int num_channels, int lookahead, int noise_shaping, int32_t initial_deltas [2]);
 int adpcm_encode_block (void *p, uint8_t *outbuf, size_t *outbufsize, const int16_t *inbuf, int inbufcount);
-int adpcm_decode_block (int16_t *outbuf, const uint8_t *inbuf, size_t inbufsize, int channels);
+int adpcm_decode_ima_block (int16_t *outbuf, const uint8_t *inbuf, size_t inbufsize, int channels);
+int adpcm_decode_sb4_block (int16_t *outbuf, const uint8_t *inbuf, size_t inbufsize, int channels);
 void adpcm_free_context (void *p);
 
 #ifdef __cplusplus 

--- a/adpcm-xq.c
+++ b/adpcm-xq.c
@@ -36,12 +36,14 @@ static const char *usage =
 "           -h     = display this help message\n"
 "           -q     = quiet mode (display errors only)\n"
 "           -r     = raw output (little-endian, no WAV header written)\n"
+"           -s     = encode as Sound Blaster 4 ADPCM\n\n"
 "           -v     = verbose (display lots of info)\n"
 "           -y     = overwrite outfile if it exists\n\n"
 " Web:       Visit www.github.com/dbry/adpcm-xq for latest version and info\n\n";
 
 #define ADPCM_FLAG_NOISE_SHAPING    0x1
 #define ADPCM_FLAG_RAW_OUTPUT       0x2
+#define ADPCM_FLAG_SB4_OUTPUT       0x4
 
 static int adpcm_converter (char *infilename, char *outfilename, int flags, int blocksize_pow2, int lookahead);
 static int verbosity = 0, decode_only = 0, encode_only = 0;
@@ -114,6 +116,10 @@ int main (argc, argv) int argc; char **argv;
 
                     case 'Y': case 'y':
                         overwrite = 1;
+                        break;
+
+                    case 'S': case 's':
+                        flags |= ADPCM_FLAG_SB4_OUTPUT;
                         break;
 
                     default:
@@ -196,12 +202,15 @@ typedef struct {
 
 #define WAVE_FORMAT_PCM         0x1
 #define WAVE_FORMAT_IMA_ADPCM   0x11
+#define WAVE_FORMAT_SB4_ADPCM   0x0200
 #define WAVE_FORMAT_EXTENSIBLE  0xfffe
 
 static int write_pcm_wav_header (FILE *outfile, int num_channels, uint32_t num_samples, uint32_t sample_rate);
-static int write_adpcm_wav_header (FILE *outfile, int num_channels, uint32_t num_samples, uint32_t sample_rate, int samples_per_block);
-static int adpcm_decode_data (FILE *infile, FILE *outfile, int num_channels, uint32_t num_samples, int block_size);
-static int adpcm_encode_data (FILE *infile, FILE *outfile, int num_channels, uint32_t num_samples, int samples_per_block, int lookahead, int noise_shaping);
+static int write_adpcm_wav_header (FILE *outfile, int num_channels, uint32_t num_samples, uint32_t sample_rate, int samples_per_block, int format_tag);
+static int adpcm_decode_data (FILE *infile, FILE *outfile, int num_channels, uint32_t num_samples, int block_size, 
+    int (*decode_block)(int16_t *, const uint8_t *, size_t , int ));
+static int adpcm_encode_data (FILE *infile, FILE *outfile, int num_channels, uint32_t num_samples, int samples_per_block, int lookahead, int noise_shaping, 
+    void *(create_context) (int , int , int , int32_t [2]));
 static void little_endian_to_native (void *data, char *format);
 static void native_to_little_endian (void *data, char *format);
 
@@ -273,7 +282,7 @@ static int adpcm_converter (char *infilename, char *outfilename, int flags, int 
                 if (WaveHeader.BlockAlign != WaveHeader.NumChannels * 2)
                     supported = 0;
             }
-            else if (format == WAVE_FORMAT_IMA_ADPCM) {
+            else if (format == WAVE_FORMAT_IMA_ADPCM || format == WAVE_FORMAT_SB4_ADPCM) {
                 if (encode_only) {
                     fprintf (stderr, "\"%s\" is ADPCM .WAV file, invalid in encode-only mode!\n", infilename);
                     return -1;
@@ -437,7 +446,9 @@ static int adpcm_converter (char *infilename, char *outfilename, int flags, int 
             fprintf (stderr, "each %d byte ADPCM block will contain %d samples * %d channels\n",
                 block_size, samples_per_block, num_channels);
 
-        if (!(flags & ADPCM_FLAG_RAW_OUTPUT) && !write_adpcm_wav_header (outfile, num_channels, num_samples, sample_rate, samples_per_block)) {
+        if (!(flags & ADPCM_FLAG_RAW_OUTPUT) && !write_adpcm_wav_header (outfile, num_channels, num_samples, sample_rate, samples_per_block,
+            (flags & ADPCM_FLAG_SB4_OUTPUT) ? WAVE_FORMAT_SB4_ADPCM : WAVE_FORMAT_IMA_ADPCM
+            )) {
             fprintf (stderr, "can't write header to file \"%s\" !\n", outfilename);
             return -1;
         }
@@ -446,9 +457,11 @@ static int adpcm_converter (char *infilename, char *outfilename, int flags, int 
             infilename, (flags & ADPCM_FLAG_RAW_OUTPUT) ? " raw " : " ", outfilename);
 
         res = adpcm_encode_data (infile, outfile, num_channels, num_samples, samples_per_block, lookahead,
-            (flags & ADPCM_FLAG_NOISE_SHAPING) ? (sample_rate > 64000 ? NOISE_SHAPING_STATIC : NOISE_SHAPING_DYNAMIC) : NOISE_SHAPING_OFF);
+            (flags & ADPCM_FLAG_NOISE_SHAPING) ? (sample_rate > 64000 ? NOISE_SHAPING_STATIC : NOISE_SHAPING_DYNAMIC) : NOISE_SHAPING_OFF,
+            (flags & ADPCM_FLAG_SB4_OUTPUT) ? adpcm_create_sb4_context : adpcm_create_ima_context
+            );
     }
-    else if (format == WAVE_FORMAT_IMA_ADPCM) {
+    else if (format == WAVE_FORMAT_IMA_ADPCM || format == WAVE_FORMAT_SB4_ADPCM) {
         if (!(flags & ADPCM_FLAG_RAW_OUTPUT) && !write_pcm_wav_header (outfile, num_channels, num_samples, sample_rate)) {
             fprintf (stderr, "can't write header to file \"%s\" !\n", outfilename);
             return -1;
@@ -457,7 +470,8 @@ static int adpcm_converter (char *infilename, char *outfilename, int flags, int 
         if (verbosity >= 0) fprintf (stderr, "decoding ADPCM file \"%s\" to%sPCM file \"%s\"...\n",
             infilename, (flags & ADPCM_FLAG_RAW_OUTPUT) ? " raw " : " ", outfilename);
 
-        res = adpcm_decode_data (infile, outfile, num_channels, num_samples, WaveHeader.BlockAlign);
+        res = adpcm_decode_data (infile, outfile, num_channels, num_samples, WaveHeader.BlockAlign, 
+            (format == WAVE_FORMAT_SB4_ADPCM) ? adpcm_decode_sb4_block : adpcm_decode_ima_block);
     }
 
     fclose (outfile);
@@ -506,7 +520,7 @@ static int write_pcm_wav_header (FILE *outfile, int num_channels, uint32_t num_s
         fwrite (&datahdr, sizeof (datahdr), 1, outfile);
 }
 
-static int write_adpcm_wav_header (FILE *outfile, int num_channels, uint32_t num_samples, uint32_t sample_rate, int samples_per_block)
+static int write_adpcm_wav_header (FILE *outfile, int num_channels, uint32_t num_samples, uint32_t sample_rate, int samples_per_block, int format_tag)
 {
     RiffChunkHeader riffhdr;
     ChunkHeader datahdr, fmthdr;
@@ -527,7 +541,7 @@ static int write_adpcm_wav_header (FILE *outfile, int num_channels, uint32_t num
 
     memset (&wavhdr, 0, sizeof (wavhdr));
 
-    wavhdr.FormatTag = WAVE_FORMAT_IMA_ADPCM;
+    wavhdr.FormatTag = format_tag;
     wavhdr.NumChannels = num_channels;
     wavhdr.SampleRate = sample_rate;
     wavhdr.BytesPerSecond = sample_rate * block_size / samples_per_block;
@@ -563,7 +577,8 @@ static int write_adpcm_wav_header (FILE *outfile, int num_channels, uint32_t num
         fwrite (&datahdr, sizeof (datahdr), 1, outfile);
 }
 
-static int adpcm_decode_data (FILE *infile, FILE *outfile, int num_channels, uint32_t num_samples, int block_size)
+static int adpcm_decode_data (FILE *infile, FILE *outfile, int num_channels, uint32_t num_samples, int block_size, 
+    int (*decode_block) (int16_t *, const uint8_t *, size_t , int ))
 {
     int samples_per_block = (block_size - num_channels * 4) * (num_channels ^ 3) + 1, percent;
     void *pcm_block = malloc (samples_per_block * num_channels * 2);
@@ -596,7 +611,7 @@ static int adpcm_decode_data (FILE *infile, FILE *outfile, int num_channels, uin
             return -1;
         }
 
-        if (adpcm_decode_block (pcm_block, adpcm_block, block_size, num_channels) != this_block_adpcm_samples) {
+        if (decode_block (pcm_block, adpcm_block, block_size, num_channels) != this_block_adpcm_samples) {
             fprintf (stderr, "adpcm_decode_block() did not return expected value!\n");
             return -1;
         }
@@ -637,7 +652,8 @@ static int adpcm_decode_data (FILE *infile, FILE *outfile, int num_channels, uin
     return 0;
 }
 
-static int adpcm_encode_data (FILE *infile, FILE *outfile, int num_channels, uint32_t num_samples, int samples_per_block, int lookahead, int noise_shaping)
+static int adpcm_encode_data (FILE *infile, FILE *outfile, int num_channels, uint32_t num_samples, int samples_per_block, int lookahead, int noise_shaping, 
+    void *(create_context) (int , int , int , int32_t [2]))
 {
     int block_size = (samples_per_block - 1) / (num_channels ^ 3) + (num_channels * 4), percent;
     int16_t *pcm_block = malloc (samples_per_block * num_channels * 2);
@@ -716,7 +732,7 @@ static int adpcm_encode_data (FILE *infile, FILE *outfile, int num_channels, uin
             average_deltas [0] >>= 3;
             average_deltas [1] >>= 3;
 
-            adpcm_cnxt = adpcm_create_context (num_channels, lookahead, noise_shaping, average_deltas);
+            adpcm_cnxt = create_context (num_channels, lookahead, noise_shaping, average_deltas);
         }
 
         adpcm_encode_block (adpcm_cnxt, adpcm_block, &num_bytes, pcm_block, this_block_adpcm_samples);


### PR DESCRIPTION
Use WAVE subformat 0x200 for SB4 ADPCM as per https://www.iana.org/assignments/wave-avi-codec-registry/wave-avi-codec-registry.xhtml
Please refer to https://wiki.multimedia.cx/index.php/Creative_8_bits_ADPCM for encoding and decoding scheme

Now I am not sure whether there are any WAVE files out there that actually use this subformat, but I figured it would be OK to use it anyway. It's main advantage over IMA is decoding speed, which is at least 50% faster and primarily targets low end and old devices that natively output 8-bit samples, such as SegaCD and/or Sound Blaster Pro. The quality is surprisingly good, all things considered.

The pull request also implements decoder for this subformat and should make it easier to add other ADPCM subformats in the future.