### PR TITLE
miscellaneous fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.16)
 
 # set the project name
-project(adpcm-xq)
+project(adpcm-xq LANGUAGES C)
 
 include(CheckLibraryExists)
 
@@ -27,4 +27,3 @@ endif()
 
 # define location for header files
 target_include_directories(adpcm-xq-exe PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} )
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,16 +3,26 @@ cmake_minimum_required(VERSION 3.16)
 # set the project name
 project(adpcm-xq)
 
+include(CheckLibraryExists)
+
 # lots of warnings and all warnings as errors
-# add_compile_options(-Wall -Wextra )
+add_compile_options(-Wall)
+# add_compile_options(-Wextra)
 
 # define as library
-add_library (adpcm-xq adpcm-xq.c)
+add_library (adpcm-lib adpcm-lib.c adpcm-dns.c)
 
 # build executable
-add_executable (adpcm-xq-exe adpcm-lib.c adpcm-xq.c)
+add_executable (adpcm-xq-exe adpcm-xq.c)
 set_property(TARGET adpcm-xq-exe PROPERTY OUTPUT_NAME adpcm-xq)
 
+check_library_exists(m pow "" HAVE_LIBM)
+if(HAVE_LIBM)
+  target_link_libraries(adpcm-lib m)
+  target_link_libraries(adpcm-xq-exe adpcm-lib)
+  target_link_libraries(adpcm-xq-exe m)
+endif()
+
 # define location for header files
-target_include_directories(adpcm-xq PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} )
+target_include_directories(adpcm-xq-exe PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ add_compile_options(-Wall)
 # add_compile_options(-Wextra)
 
 # define as library
-add_library (adpcm-lib adpcm-lib.c adpcm-dns.c)
+add_library (adpcm-lib STATIC adpcm-lib.c adpcm-dns.c)
 
 # build executable
 add_executable (adpcm-xq-exe adpcm-xq.c)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,9 +5,11 @@ project(adpcm-xq)
 
 include(CheckLibraryExists)
 
+if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
 # lots of warnings and all warnings as errors
-add_compile_options(-Wall)
+  add_compile_options(-Wall)
 # add_compile_options(-Wextra)
+endif()
 
 # define as library
 add_library (adpcm-lib STATIC adpcm-lib.c adpcm-dns.c)

--- a/adpcm-dns.c
+++ b/adpcm-dns.c
@@ -51,6 +51,8 @@ void generate_dns_values (const int16_t *samples, int sample_count, int num_chan
     int filtered_count = sample_count - FILTER_LENGTH + 1, i;
     float *low_freq, *high_freq;
 
+    (void) sample_rate; // unused.
+
     memset (values, 0, sample_count * sizeof (values [0]));
 
     if (filtered_count <= 0)

--- a/adpcm-lib.c
+++ b/adpcm-lib.c
@@ -812,7 +812,7 @@ int adpcm_encode_block_ex (void *p, uint8_t *outbuf, size_t *outbufsize, const i
         for (ch = 0; ch < pcnxt->num_channels; ch++) {
             rms_error_t min_error = MAX_RMS_ERROR;
             rms_error_t error_per_index [89];
-            int best_index, tindex;
+            int best_index = 0, tindex;
 
             for (tindex = 0; tindex <= 88; tindex++) {
                 struct adpcm_channel chan = pcnxt->channels [ch];

--- a/adpcm-lib.c
+++ b/adpcm-lib.c
@@ -812,9 +812,9 @@ int adpcm_encode_block_ex (void *p, uint8_t *outbuf, size_t *outbufsize, const i
         for (ch = 0; ch < pcnxt->num_channels; ch++) {
             rms_error_t min_error = MAX_RMS_ERROR;
             rms_error_t error_per_index [89];
-            int best_index;
+            int best_index, tindex;
 
-            for (int tindex = 0; tindex <= 88; tindex++) {
+            for (tindex = 0; tindex <= 88; tindex++) {
                 struct adpcm_channel chan = pcnxt->channels [ch];
 
                 chan.index = tindex;
@@ -832,7 +832,7 @@ int adpcm_encode_block_ex (void *p, uint8_t *outbuf, size_t *outbufsize, const i
 
             // we use a 3-wide average window because the min_error_nbit() results can be noisy
 
-            for (int tindex = 0; tindex <= 87; tindex++) {
+            for (tindex = 0; tindex <= 87; tindex++) {
                 rms_error_t terror = error_per_index [tindex];
 
                 if (tindex)

--- a/adpcm-xq.c
+++ b/adpcm-xq.c
@@ -820,13 +820,14 @@ static int adpcm_encode_data (FILE *infile, FILE *outfile, int num_channels, int
         if (flags & ADPCM_FLAG_MEASURE_NOISE) {
             int16_t *pcm_decoded = malloc (samples_per_block * num_channels * 2);
             double rms_noise [2] = { 0.0, 0.0 };
+            int i;
 
             if (adpcm_decode_block_ex (pcm_decoded, adpcm_block, block_size, num_channels, bps) != this_block_adpcm_samples) {
                 fprintf (stderr, "\radpcm_decode_block_ex() did not return expected value!\n");
                 return -1;
             }
 
-            for (int i = 0; i < this_block_pcm_samples * num_channels; i += num_channels) {
+            for (i = 0; i < this_block_pcm_samples * num_channels; i += num_channels) {
                 int32_t error = fabs (pcm_block [i] - pcm_decoded [i]);
 
                 if (error > max_error [0])

--- a/adpcm-xq.c
+++ b/adpcm-xq.c
@@ -55,7 +55,7 @@ static int verbosity = 0, decode_only = 0, encode_only = 0, flags = ADPCM_FLAG_N
 static int lookahead = 3, blocksize_pow2 = 0, encode_width_bits = 4;
 static double static_shaping_weight = 0.0;
 
-int main (argc, argv) int argc; char **argv;
+int main (int argc, char **argv)
 {
     int overwrite = 0, asked_help = 0;
     char *infilename = NULL, *outfilename = NULL;


### PR DESCRIPTION
A few minor fixes, and a cmake update/fix:

* adpcm-dns.c: fix unused parameter warning for generate_dns_values()
* adpcm-xq.c: fix -Wold-style-definition for main()
* fix build in C89 mode
* adpcm-lib.c: silence 'may be used uninitialized' warning for best_index
* cmake fixes / updates:
  - fix library target name and sources
  - link adpcm-xq exe to adpcm-lib
  - link to libm if available, for floor(), log10(), etc.
  - enable -Wall
