### PR TITLE
Cmake updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
 
-# set macOS build options
-set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64" CACHE STRING "" FORCE)
-
 # set the project name
 project(adpcm-xq LANGUAGES C)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.0...3.5)
 
 # set the project name
 project(adpcm-xq LANGUAGES C)


### PR DESCRIPTION
- reverts commit f6753acbdf4a307baff620817a7446d90297fb11:
  as discussed at https://github.com/dbry/adpcm-xq/pull/25#issuecomment-2397753636

- reduce cmake version requirement:
  builds happily with cmake >= 3.0
