### PR TITLE
fix CMake build with MSVS (linker errors when there is no LIBM)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,8 @@ if(HAVE_LIBM)
   target_link_libraries(adpcm-lib m)
   target_link_libraries(adpcm-xq-exe adpcm-lib)
   target_link_libraries(adpcm-xq-exe m)
+else()
+  target_link_libraries(adpcm-xq-exe adpcm-lib)
 endif()
 
 # define location for header files


### PR DESCRIPTION
fix in CMakeLists.txt to link adpcm-xq correctly against adpcm-lib when there is no LIBM 

linker errors (without this fix):
```
adpcm-xq.obj : error LNK2019: unresolved external symbol adpcm_sample_count_to_block_size referenced in function write_adpcm_wav_header
adpcm-xq.obj : error LNK2019: unresolved external symbol adpcm_block_size_to_sample_count referenced in function adpcm_converter
adpcm-xq.obj : error LNK2019: unresolved external symbol adpcm_align_block_size referenced in function adpcm_converter
adpcm-xq.obj : error LNK2019: unresolved external symbol adpcm_create_context referenced in function adpcm_encode_data
... 4 more ...
adpcm-xq.exe : fatal error LNK1120: 8 unresolved externals
```